### PR TITLE
bug report

### DIFF
--- a/Ocean/Ocean.pro
+++ b/Ocean/Ocean.pro
@@ -10,7 +10,6 @@ CONFIG += c++17
 
 DEFINES += QT_DEPRECATED_WARNINGS
 
-
 SOURCES += \
     imports/importmanager.cpp \
     main.cpp \

--- a/Ocean/imports/importmanager.cpp
+++ b/Ocean/imports/importmanager.cpp
@@ -56,7 +56,7 @@ ImportManager::~ImportManager()
 
 void ImportManager::CallFileDialogWithDel()
 {
-    const QStringList pathOfFiles = ImportManager::importerWindow->QFileDialog::getOpenFileNames(0, "Import Music", "", "*.mp3 *.wav");
+    const QStringList pathOfFiles = ImportManager::importerWindow->QFileDialog::getOpenFileNames(0, "Import Music", "", "*.mp3 *.wav *.m4a");
 
     if(pathOfFiles.QStringList::isEmpty())
         return;
@@ -68,7 +68,7 @@ void ImportManager::CallFileDialogWithDel()
 
 void ImportManager::CallFileDialogOnlyCopy()
 {
-    const QStringList pathOfFiles = ImportManager::importerWindow->QFileDialog::getOpenFileNames(0, "Import Music", "", "*.mp3 *.wav");
+    const QStringList pathOfFiles = ImportManager::importerWindow->QFileDialog::getOpenFileNames(0, "Import Music", "", "*.mp3 *.wav *.m4a");
 
     if(pathOfFiles.QStringList::isEmpty())
         return;

--- a/Ocean/playlists/playlist.cpp
+++ b/Ocean/playlists/playlist.cpp
@@ -54,7 +54,7 @@ Playlist::Playlist()
         //Reboot songs inside playlist with all songs
         //For get all songs into 'allSongs' variable
         Playlist::cd->QDir::setCurrent(QCoreApplication::applicationDirPath() + "/music/");
-        Playlist::allSongs = Playlist::cd->QDir::entryList(QStringList() << "*.mp3" << "*.MP3" << "*.wav" << "*.WAV", QDir::Files);
+        Playlist::allSongs = Playlist::cd->QDir::entryList(QStringList() << "*.mp3" << "*.MP3" << "*.wav" << "*.WAV" << "*.m4a" << "*.M4A", QDir::Files);
 
         QMediaPlaylist *buffer = new QMediaPlaylist();
 
@@ -191,7 +191,7 @@ void Playlist::RenameSelectedPlayList(const QString &newName, const QString &cur
 
     if(Playlist::RenamePlayList(newName, currentName))
     {
-        qDebug() << "Playlist name: " << currentName;
+        qDebug() << "Playlist current name: " << currentName;
         qDebug() << "Playlist new name: " << newName;
         qDebug() << "playlist successed renamed";
     }
@@ -406,9 +406,8 @@ bool Playlist::LookingForPlayList(const QString &name, QMediaPlaylist *medialist
 
     Playlist::CheckSettingsDir();
 
-    medialist->QMediaPlaylist::clear();
     medialist->QMediaPlaylist::load(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + "/bin/" + name), "m3u");
-    medialist->setCurrentIndex(1);
+    medialist->setCurrentIndex(0);
 
     if(!medialist->QMediaPlaylist::isEmpty())
         return true;

--- a/Ocean/playlists/playlist.h
+++ b/Ocean/playlists/playlist.h
@@ -36,8 +36,6 @@ public:
 
     /*-------------------------------------------------------SIGNALS-------------------------------------------------------*/
     /*
-        1) set playlist for player class
-            1.1) set current playlist
         2) save
             2.1) save current playlist by name and media playlist
             2.2) save selected playlist by name
@@ -53,8 +51,6 @@ public:
            7.2) add song into platlist from all songs (default playlist)
     */
 signals:
-    /*----------------------------------------set playlist player----------------------------------------*/
-    void SetCurrentPlayList(QMediaPlaylist *currentPlaylist);
     /*----------------------------------------save------------------------------------------*/
     void CallOutSaveCurrentPlayList(const QString &name, const QStringList &newListOfSongs, QMediaPlaylist *currentPlaylist);
     void CallOutSaveSelectedPlayList(const QString &name, const QStringList &newListOfSongs);

--- a/Ocean/ui/addmusicwidget.cpp
+++ b/Ocean/ui/addmusicwidget.cpp
@@ -85,6 +85,8 @@ void AddMusicWidget::DoubleClickedAddedSongsList(QListWidgetItem *item)
 
 void AddMusicWidget::ClickedCancel()
 {
+    AddMusicWidget::allSongs->QListWidget::clear();
+    AddMusicWidget::addedSongs->QListWidget::clear();
     emit this->AddMusicWidget::BreakeWidget();
 
     return;
@@ -92,6 +94,8 @@ void AddMusicWidget::ClickedCancel()
 
 void AddMusicWidget::ClickedOkay()
 {
+    AddMusicWidget::allSongs->QListWidget::clear();
+    AddMusicWidget::addedSongs->QListWidget::clear();
     emit this->AddMusicWidget::SendListWithSongs(AddMusicWidget::GetAddedSongsFromListWidget());
 
     return;

--- a/Ocean/ui/ocean.cpp
+++ b/Ocean/ui/ocean.cpp
@@ -158,8 +158,6 @@ Ocean::Ocean(QWidget *parent)
     //Timer for check widget of create playlist
     Ocean::timerForCheckWidgets->QTimer::setInterval(500);
     Ocean::timerForCheckWidgets->QTimer::start();
-    //String to get selected playlist
-    Ocean::currentPlaylist = "";
 
     //Load playlists
     QStringList buffer = Ocean::GetNamesOfPlaylistsFromBinDir();
@@ -224,7 +222,6 @@ Ocean::Ocean(QWidget *parent)
     //Player manager
     QObject::connect(Ocean::playTrack, &QPushButton::clicked, Ocean::playermanager, &QMediaPlayer::play);
     QObject::connect(Ocean::stopTrack, &QPushButton::clicked, Ocean::playermanager, &QMediaPlayer::stop);
-    QObject::connect(Ocean::playlistmanager, &Playlist::SetCurrentPlayList, Ocean::playermanager, &QMediaPlayer::setPlaylist); //check THIS SIDE BY DOUBLE CLICKED IN PLAYLIST WODGET
     //Playlist manager
     QObject::connect(Ocean::nextTrack, &QPushButton::clicked, Ocean::playlistmanager, &Playlist::SetNextTrack);
     QObject::connect(Ocean::previousTrack, &QPushButton::clicked, Ocean::playlistmanager, &Playlist::SetPreviousTrack);
@@ -232,13 +229,14 @@ Ocean::Ocean(QWidget *parent)
 
     //UI-----------------------------------------------
     //UI Lists
-    QObject::connect(Ocean::playLists, &QListWidget::itemClicked, this, &Ocean::GetNameOfSelectedPlaylist);
-    QObject::connect(Ocean::playLists, &QListWidget::itemDoubleClicked, this, &Ocean::GetNameOfSelectedPlaylist);
-    QObject::connect(Ocean::playLists, &QListWidget::itemDoubleClicked, this, &Ocean::GetNamesOfSongsToMusicList);
     QObject::connect(Ocean::playLists, &QListWidget::itemClicked, this, &Ocean::GetNamesOfSongsToMusicList);
-    QObject::connect(Ocean::playLists, &QListWidget::itemDoubleClicked, this, &Ocean::SetPlayList);                           //check THIS SIDE BY DOUBLE CLICKED IN PLAYLIST WODGET
+
+    QObject::connect(Ocean::playLists, &QListWidget::itemDoubleClicked, this, &Ocean::SetPlayList);
+    QObject::connect(Ocean::playLists, &QListWidget::itemDoubleClicked, this, &Ocean::GetNamesOfSongsToMusicList);
+
     QObject::connect(Ocean::playLists, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(ShowContextMenuOfPlayList(QPoint)));
     QObject::connect(Ocean::musicList, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(ShowContextMenuOfMusicList(QPoint)));
+
     QObject::connect(this, &Ocean::CallOutPassNamesOfSongsToMusicList, this, &Ocean::PassNamesOfSongsToMusicList);
     QObject::connect(this, &Ocean::CallOutToCreateWindowThisWidgetToGetAddedTracks, this, &Ocean::CallWidgetAfterCreatePlaylistSlot);
     //Widget for get string from user
@@ -491,8 +489,7 @@ void Ocean::SetPlayList(QListWidgetItem *item)
     emit Ocean::playlistmanager->Playlist::CallOutSetCurrentPlayListName(item->QListWidgetItem::text());
     //load
     Ocean::playlistmanager->Playlist::LoadPlayList(Ocean::playlistmanager->Playlist::GetCurrentPlayListName() + ".m3u");
-    //Emit signal from Playlist.h with current playlist
-    emit Ocean::playlistmanager->Playlist::SetCurrentPlayList(Ocean::playlistmanager->Playlist::GetCurrentPlayList());
+    Ocean::playermanager->QMediaPlayer::setPlaylist(Ocean::playlistmanager->Playlist::GetCurrentPlayList());
     //show songs in music list
     emit this->Ocean::CallOutPassNamesOfSongsToMusicList(Ocean::playlistmanager->Playlist::GetSongsFromCurrentPlayList(item->QListWidgetItem::text() + ".m3u"));
 
@@ -585,15 +582,6 @@ void Ocean::IfgetAddedTracksFromWidgetClosed()
         this->QWidget::setEnabled(true);
     else
         this->QWidget::setDisabled(true);
-
-    return;
-}
-
-void Ocean::GetNameOfSelectedPlaylist(QListWidgetItem *item)
-{
-    Ocean::currentPlaylist = item->QListWidgetItem::text();
-
-    qDebug() << "Selected playlist: " << Ocean::currentPlaylist;
 
     return;
 }

--- a/Ocean/ui/ocean.h
+++ b/Ocean/ui/ocean.h
@@ -167,15 +167,13 @@ private slots:
         1) Timer for Ocean::getStringFromUser
         2) Timer for Ocean::getStringWithSelectedPlaylist
         3) Timer for Ocean::getAddedTracksFromWidget
-        4) Get name of selected playlist
-        5) Get names of playlists from 'bin' dir
-        6) Create widget after widget for get string from user
+        4) Get names of playlists from 'bin' dir
+        5) Create widget after widget for get string from user
     */
 
     void IfgetStringFromUserClosed();//-----------------------------------------1
     void IfgetStringWithSelectedPlaylistClosed();//-----------------------------2
     void IfgetAddedTracksFromWidgetClosed();//----------------------------------3
-    void GetNameOfSelectedPlaylist(QListWidgetItem *item);//--------------------4
     QStringList GetNamesOfPlaylistsFromBinDir();//------------------------------5
     void CallWidgetAfterCreatePlaylistSlot();//---------------------------------6
 
@@ -214,7 +212,6 @@ private:
     //TOOLS-----------------------------------------------------------
     //ToolS for widgets
     QTimer *timerForCheckWidgets = nullptr;
-    QString currentPlaylist;
     QStringList bufferOfAddedTracks = {};
     QDir *cd = nullptr;
     //TOOLS-----------------------------------------------------------


### PR DESCRIPTION
-- need to fix
--- bug with double clicked on playlist (button 'stop' works only after button 'play')
--- bug with format of '.m4a'. Showed in second start of app
--- bug with tracks (just check it after two bugs above)

-- fixed
--- bug with create new playlist (showed last one list)

-- refactored
--- refactored SIGNAL/SLOT in main ui class (ocean.cpp)
---- delete slot with set current playlist and make it code inside slot of Ocean.cpp **SetPlayList(QListWidgetItem *item)**